### PR TITLE
Fixing a problem in aligning `navbar-nav` items

### DIFF
--- a/scss/_rtl.scss
+++ b/scss/_rtl.scss
@@ -12,8 +12,8 @@
   }
 
   .navbar-nav .nav-item + .nav-item {
-    margin-right: 1rem;
-    margin-left: inherit;
+    margin-right: inherit;
+    margin-left: 1rem;
   }
 
   th {


### PR DESCRIPTION
nav items within navbar-nav in column mode, don't align correctly which is fixed now

![bootstrap-rtl_01](https://user-images.githubusercontent.com/29872642/67128933-08a2ea00-f20a-11e9-8ea3-c320b5e25033.PNG)

Reproduction Code
```<!DOCTYPE html>
<html lang="en">
<head>
	<meta charset="UTF-8">
	<link rel="stylesheet" href="css/bootstrap.min.css">
	<link rel="stylesheet" href="css/bootstrap-rtl.min.css">
	<title>Issue Reproduction</title>
</head>

<body dir="rtl">
	<nav class="navbar navbar-dark bg-dark">
		<div class="container">
			<a class="navbar-brand" href="#">Brand</a>
			<div class="navbar-nav">
				<a class="nav-item nav-link active" href="#">Home</a>
				<a class="nav-item nav-link" href="#">Services</a>
				<a class="nav-item nav-link" href="#">About Us</a>
				<a class="nav-item nav-link" href="#">Contact Us</a>
			</div>
		</div>
	</nav>

	<script src="js/query.min.js"></script>
	<script src="js/popper.min.js"></script>
	<script src="js/bootstrap.min.js"></script>
</body>
</html>
```